### PR TITLE
Return current progress when canceling animation

### DIFF
--- a/Source/INTUAnimationEngine.h
+++ b/Source/INTUAnimationEngine.h
@@ -117,7 +117,9 @@ typedef NS_OPTIONS(NSUInteger, INTUAnimationOptions) {
  Cancels the currently active animation with the given animation ID.
  The completion block for the animation will be executed, with the finished parameter equal to NO.
  If there is no active animation for the given ID, this method will do nothing.
+ 
+ @return current progress of animation. It can be used to resume or start to continue the paused animation.
  */
-+ (void)cancelAnimationWithID:(INTUAnimationID)animationID;
++ (CGFloat)cancelAnimationWithID:(INTUAnimationID)animationID;
 
 @end

--- a/Source/INTUAnimationEngine.m
+++ b/Source/INTUAnimationEngine.m
@@ -222,9 +222,9 @@ static id _sharedInstance;
 /**
  Cancels the currently active animation with the given animation ID. The completion block for the animation will be executed, with the finished parameter equal to NO.
  */
-+ (void)cancelAnimationWithID:(INTUAnimationID)animationID
++ (CGFloat)cancelAnimationWithID:(INTUAnimationID)animationID
 {
-    [[self sharedInstance] removeAnimationWithID:animationID didFinish:NO];
+    return [[self sharedInstance] removeAnimationWithID:animationID didFinish:NO];
 }
 
 - (id)init
@@ -265,7 +265,7 @@ static id _sharedInstance;
     [self.activeAnimations setObject:animation forKey:@(animation.animationID)];
 }
 
-- (void)removeAnimationWithID:(INTUAnimationID)animationID didFinish:(BOOL)finished
+- (CGFloat)removeAnimationWithID:(INTUAnimationID)animationID didFinish:(BOOL)finished
 {
     INTUAnimation *animation = [self.activeAnimations objectForKey:@(animationID)];
     [animation complete:finished];
@@ -273,6 +273,7 @@ static id _sharedInstance;
     if ([self.activeAnimations count] == 0) {
         self.displayLink.paused = YES;
     }
+    return animation.progress;
 }
 
 @end


### PR DESCRIPTION
Cancel animation should return current animation progress to use later. It can be used to resume or start to continue the paused animation.
